### PR TITLE
impr: additional and pooler support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       ctfd:
-        image: ctferio/ctfd:3.7.6-0.3.0-rc0@sha256:0822462d54fbf9788b2fcdfa2e50a112ff23903094faf2ae5066d020f1a9babb
+        image: ctferio/ctfd:3.7.7-0.3.0@sha256:c6b9d8ab4c7c674441e2c49170f3cbff1e9df3cda22cf856ad7f9a8c6193ebe3
         ports:
           - 8000:8000
         env:
@@ -22,7 +22,7 @@ jobs:
           PLUGIN_SETTINGS_CM_MANA_TOTAL: 10
 
       chall-manager: 
-        image: ctferio/chall-manager:v0.3.2@sha256:db05b77564502a2db3409d0970810b8586b74d8fa40d0f234ca4a087d06c28d2
+        image: ctferio/chall-manager:v0.4.2@sha256:fad0ed724caa5aff5e877be0ff5fec454aacefa582c01f2728cec1f0ce6b3272
         ports:
           - 8080:8080
     steps:

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@
 Golang client for interacting with [CTFd](https://ctfd.io/) in the specific context of the [Chall-Manager plugin](https://github.com/ctfer-io/ctfd-chall-manager).
 
 Last version tested on:
-- [CTFd 3.7.5](https://github.com/CTFd/CTFd/releases/tag/3.7.5)
-- [CTFd-Chall-Manager v0.2.1](https://github.com/ctfer-io/ctfd-chall-manager/releases/tag/v0.2.1)
+- [CTFd 3.7.7](https://github.com/CTFd/CTFd/releases/tag/3.7.7)
+- [CTFd-Chall-Manager v0.3.0](https://github.com/ctfer-io/ctfd-chall-manager/releases/tag/v0.3.0)

--- a/api/challenges.go
+++ b/api/challenges.go
@@ -44,6 +44,8 @@ type (
 		Timeout       *int              `json:"timeout,omitempty"`
 		Until         *string           `json:"until,omitempty"`
 		Additional    map[string]string `json:"additional,omitempty"`
+		Min           int               `json:"min"`
+		Max           int               `json:"max"`
 	}
 )
 
@@ -81,12 +83,15 @@ type (
 
 		// CTFer.io DynamicIaC arguments
 
-		DestroyOnFlag bool    `json:"destroy_on_flag"`
-		Shared        bool    `json:"shared"`
-		ManaCost      int     `json:"mana_cost"`
-		ScenarioID    int     `json:"scenario_id"`
-		Timeout       *int    `json:"timeout,omitempty"`
-		Until         *string `json:"until,omitempty"`
+		DestroyOnFlag bool              `json:"destroy_on_flag"`
+		Shared        bool              `json:"shared"`
+		ManaCost      int               `json:"mana_cost"`
+		ScenarioID    int               `json:"scenario_id"`
+		Timeout       *int              `json:"timeout,omitempty"`
+		Until         *string           `json:"until,omitempty"`
+		Additional    map[string]string `json:"additional,omitempty"`
+		Min           int               `json:"min"`
+		Max           int               `json:"max"`
 	}
 )
 

--- a/api/model.go
+++ b/api/model.go
@@ -30,12 +30,15 @@ type (
 
 		// CTFer.io DynamicIaC arguments
 
-		DestroyOnFlag bool    `json:"destroy_on_flag"`
-		Shared        bool    `json:"shared"`
-		ManaCost      int     `json:"mana_cost"`
-		ScenarioID    int     `json:"scenario_id"`
-		Until         *string `json:"until,omitempty"`
-		Timeout       *int    `json:"timeout,omitempty"`
+		DestroyOnFlag bool              `json:"destroy_on_flag"`
+		Shared        bool              `json:"shared"`
+		ManaCost      int               `json:"mana_cost"`
+		ScenarioID    int               `json:"scenario_id"`
+		Until         *string           `json:"until,omitempty"`
+		Timeout       *int              `json:"timeout,omitempty"`
+		Additional    map[string]string `json:"additional,omitempty"`
+		Min           int               `json:"min"`
+		Max           int               `json:"max"`
 	}
 
 	Instance struct {


### PR DESCRIPTION
This PR improves the `additional` k=v map support, and adds support of the pooler `min` and `max` attributes for challenges.
I'll wait for additional on instances later for another PR.